### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -1,4 +1,6 @@
 name: Rust Code Quality Check
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/sibears/farm/security/code-scanning/16](https://github.com/sibears/farm/security/code-scanning/16)

To fix the problem, add a `permissions` block—either at the workflow root or at the job level. The minimal starting set per the CodeQL suggestion is `contents: read`, which all GitHub workflows should have by default, but explicitly stating it ensures only read access is permitted. Given the operations in the `clippy-check` job do not require more than read access, and there are no steps that interact with issues, PRs, or write to the repo, this is the correct level of privilege.

The optimal, straightforward way is to add:
```yaml
permissions:
  contents: read
```
directly after the workflow name (line 2), so it applies to all jobs, or inside the `clippy-check` job if more granular control is later needed. The standard is to do this near the top. No changes to code logic, imports, or methods are needed—just insertion of the permissions block.

**Change:**  
- Insert `permissions:` after the workflow name on line 2.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
