### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   rust-check:
     uses: ./.github/workflows/rust-check.yml
+    permissions: {}
   build-and-push:
     runs-on: ubuntu-latest
     needs: rust-check


### PR DESCRIPTION
Potential fix for [https://github.com/sibears/farm/security/code-scanning/15](https://github.com/sibears/farm/security/code-scanning/15)

To fix this problem, we need to explicitly define a `permissions` block for the `rust-check` job to restrict the permissions of the GITHUB_TOKEN used by that job. The minimal starting point is to add `permissions: {}` to the job definition, which grants no permissions, unless the job needs specific access. Since the job seems to run code checks (Rust related), it doesn't appear to require any write permissions to contents, packages, or other scopes; a read-only (or empty) permissions block is safest. This can be done by adding a `permissions: {}` line after the `uses:` line for the `rust-check` job.

Alternatively, if all jobs should inherit the same tight permissions, you may add a workflow-wide `permissions:` block at the top level, but since one job (`build-and-push`) already has a more permissive block (`contents: read` and `packages: write`), it is cleanest to restrict only the missing job (`rust-check`) to minimal permissions.

**Edit:**  
- File: `.github/workflows/build-backend.yml`
- Region: Under `rust-check:`
- Add: `permissions: {}` immediately after `uses: ./.github/workflows/rust-check.yml`

No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
