### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -7,6 +7,8 @@ jobs:
   python-check:
     name: Python Lint and Type Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/sibears/farm/security/code-scanning/5](https://github.com/sibears/farm/security/code-scanning/5)

To fix the problem, we need to add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN available in the job. For this Python code quality check workflow, read access to the repository contents (to allow actions/checkout to work) is all that is needed. The `permissions` block can be added at either the workflow root (affecting all jobs), or at the job level. To be minimally invasive and clear, we should add the following to the job definition of `python-check`: 

```yaml
permissions:
  contents: read
```

This should be added just after the `runs-on: ubuntu-latest` line within the job definition. No additional imports, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
